### PR TITLE
[test] use tape not tap for node test

### DIFF
--- a/test/node/node-test.js
+++ b/test/node/node-test.js
@@ -1,5 +1,5 @@
 
-var test = require('tap').test;
+var test = require('tape');
 var builtins = require('../../index.js');
 
 test('test that all the modules are set', function (t) {


### PR DESCRIPTION
@thlorenz discovered that we where using `tap` and not `tape` (required by the browser tests). This pull request fixes that issue.
