### PR TITLE
[fix] require console modules for those module system there don't detect it

### DIFF
--- a/builtin/_stream_readable.js
+++ b/builtin/_stream_readable.js
@@ -365,7 +365,6 @@ function chunkInvalid(state, chunk) {
       chunk !== undefined &&
       !state.objectMode &&
       !er) {
-    console.log('chunk: ', chunk);
     er = new TypeError('Invalid non-string/buffer chunk');
   }
   return er;

--- a/builtin/events.js
+++ b/builtin/events.js
@@ -20,6 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var util = require('util');
+var console = require('console');
 
 function EventEmitter() {
   this._events = this._events || {};

--- a/builtin/util.js
+++ b/builtin/util.js
@@ -20,6 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 var shims = require('_shims');
+var console = require('console');
 
 var formatRegExp = /%[sdj%]/g;
 exports.format = function(f) {


### PR DESCRIPTION
For some reason there was a `console` in `_stream_readable.js` but its not in the latest stable version of node so I assume it can just be removed.

Fixes #26
