### PR TITLE
Use `buffer` instead of `native-buffer-browserify`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ require('browser-builtins');
   crypto: '/user/node_modules/browser-builtins/node_modules/crypto-browserify/index.js',
   console: '/user/node_modules/browser-builtins/node_modules/console-browserify/index.js',
   zlib: '/user/node_modules/browser-builtins/node_modules/zlib-browserify/index.js',
-  buffer: '/user/node_modules/browser-builtins/node_modules/buffer-browserify/index.js',
+  buffer: '/user/node_modules/browser-builtins/node_modules/buffer/index.js',
   constants: '/user/node_modules/browser-builtins/node_modules/constants-browserify/constants.json',
   os: '/user/node_modules/browser-builtins/node_modules/os-browserify/browser.js'
 }

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ core['vm'] = require.resolve('vm-browserify');
 core['crypto'] = require.resolve('crypto-browserify');
 core['console'] = require.resolve('console-browserify');
 core['zlib'] = require.resolve('zlib-browserify');
-core['buffer'] = require.resolve('native-buffer-browserify');
+core['buffer'] = require.resolve('buffer/');
 core['constants'] = require.resolve('constants-browserify');
 core['os'] = path.resolve(require.resolve('os-browserify'), '..', 'browser.js');
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "vm-browserify": "0.0.x",
     "crypto-browserify": "1.0.x",
     "http-browserify": "1.0.x",
-    "native-buffer-browserify": "1.0.x",
+    "buffer": "2.4.x",
     "zlib-browserify": "0.0.x",
     "constants-browserify": "0.0.x",
     "os-browserify": "0.1.x"
@@ -50,7 +50,7 @@
     "constants": "constants-browserify",
     "crypto": "crypto-browserify",
     "http": "http-browserify",
-    "buffer": "native-buffer-browserify",
+    "buffer": "buffer",
     "os": "os-browserify",
     "vm": "vm-browserify",
     "zlib": "zlib-browserify",


### PR DESCRIPTION
`native-buffer-browserify` was renamed to `buffer` many months ago and
all future updates are only be published to the new package name.
