### PR TITLE
Export empty object rather than undefined in 'fs'

### DIFF
--- a/builtin/fs.js
+++ b/builtin/fs.js
@@ -2,3 +2,5 @@
 // not implemented
 // The reason for having an empty file and not throwing is to allow
 // untraditional implementation of this module.
+
+module.exports = {};


### PR DESCRIPTION
Exporting `undefined` causes some troubles, for example, mocha does [`require('fs').existsSync`](https://github.com/mochajs/mocha/blob/master/lib/utils.js#L8), which raises blocking error.

Anycase, standard practice is to export an empty object:
https://gist.github.com/defunctzombie/4339901#ignore-a-module